### PR TITLE
Implement --add-entity feature

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,27 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "Release",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": []
+    }
+  ]
+}

--- a/src/CLI/CMakeLists.txt
+++ b/src/CLI/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(${PROJECT_NAME}
     GinnungagapCLI/CSVUnpack/Unpack.cpp
     GinnungagapCLI/CSVUnpack/Pack.cpp
     GinnungagapCLI/CSVUnpack/MXEInfo.cpp
-)
+ "GinnungagapCLI/CSVUnpack/MXEUtil.cpp")
 
 # Done
 # Allow CMake to build libraries

--- a/src/CLI/GinnungagapCLI/CSVUnpack/MXEInfo.cpp
+++ b/src/CLI/GinnungagapCLI/CSVUnpack/MXEInfo.cpp
@@ -88,15 +88,87 @@ std::vector<ParameterErrorData> checkParameterTableCSVErrors(const std::string& 
     return param_IDs;
 }
 
-
-
 std::vector<ParameterErrorData> checkParameterTableCSVErrors(const std::filesystem::path& params_root)
 {
     return checkParameterTableCSVErrors(params_root.string());
 }
 
 
-uint32_t nextAvailableID(const std::filesystem::path& root_path)
+std::vector<EntityErrorData> checkEntityTableCSVErrors(const std::string& entities_root)
+{
+    std::vector<EntityErrorData> entity_IDs;
+    std::vector<std::string> csv_names;
+    for (const auto& f : CSVFile::getCSVFiles(entities_root))
+    {
+        auto csv = CSVFile::fromFile(f);
+
+        for (uint32_t row_idx = 1; row_idx < csv.rowCount(); ++row_idx)
+        {
+            const auto& row = csv[row_idx];
+            uint32_t val;
+
+            if (!row.size())
+                continue;
+
+            try
+            {
+                val = std::stoul(row[0]);
+            }
+            catch (const std::exception& e)
+            {
+                std::cout << "ID value '" + row[0] + "' for row " + std::to_string(row_idx) + " of CSV file '" + f.string() + "' cannot be interpreted as an unsigned integer" << std::endl;
+                exit(1);
+            }
+            entity_IDs.emplace_back(val, row_idx, (uint32_t)csv_names.size());
+        }
+        csv_names.push_back(f.filename().string());
+    }
+
+    // Sort into ascending order
+    std::sort(entity_IDs.begin(), entity_IDs.end(), [](const EntityErrorData& a, const EntityErrorData& b) { return a.ID < b.ID; });
+
+    // Now check if the list contains duplicate IDs:
+    std::map<uint32_t, std::set<uint32_t>> duplicate_ids;
+    for (int i = 1; i < entity_IDs.size(); ++i)
+    {
+        auto idx = entity_IDs[i - 1].ID;
+        auto next_idx = entity_IDs[i].ID;
+
+        // Check for duplicates
+        if (idx == next_idx)
+        {
+            duplicate_ids[idx].emplace(i - 1);
+            duplicate_ids[idx].emplace(i);
+        }
+    }
+
+    // Report errors
+    if (duplicate_ids.size())
+    {
+        for (const auto& [id, indices] : duplicate_ids)
+        {
+            std::cout << "Error: Parameter ID '" << id << "' is used by multiple parameter sets:\n";
+            for (auto idx : indices)
+            {
+                const auto& param_ref = entity_IDs[idx];
+                std::cout << "[" << csv_names[param_ref.csv_idx] << "], row " << param_ref.row << std::endl;
+            }
+        }
+    }
+    
+    if (!duplicate_ids.empty())
+        exit(1);
+
+    return entity_IDs;
+}
+
+std::vector<EntityErrorData> checkEntityTableCSVErrors(const std::filesystem::path& params_root)
+{
+    return checkEntityTableCSVErrors(params_root.string());
+}
+
+
+uint32_t nextAvailableParamID(const std::filesystem::path& root_path)
 {
     const std::filesystem::path params_root   = root_path/"parameters";
     const std::filesystem::path metadata_path = root_path/"metadata.txt";
@@ -114,4 +186,24 @@ uint32_t nextAvailableID(const std::filesystem::path& root_path)
     }
     
     return checkParameterTableCSVErrors(params_root).size();
+}
+
+uint32_t nextAvailableEntityID(const std::filesystem::path& root_path)
+{
+    const std::filesystem::path entities_root = root_path / "entities";
+    const std::filesystem::path metadata_path = root_path / "metadata.txt";
+
+    if (!doesFileExist(metadata_path))
+    {
+        std::cout << "Error: Not an MXE unpack. File " << metadata_path.string() << " does not exist." << std::endl;
+        exit(1);
+    }
+
+    // Entities may not exist, e.g. game_info.mxe
+    if (!doesDirectoryExist(entities_root))
+    {
+        return 0;
+    }
+
+    return checkEntityTableCSVErrors(entities_root).back().ID+1;
 }

--- a/src/CLI/GinnungagapCLI/CSVUnpack/MXEInfo.hpp
+++ b/src/CLI/GinnungagapCLI/CSVUnpack/MXEInfo.hpp
@@ -16,7 +16,24 @@ struct ParameterErrorData
     {}
 };
 
+struct EntityErrorData
+{
+    uint32_t ID;
+    uint32_t row;
+    uint32_t csv_idx;
+
+    EntityErrorData(uint32_t ID, uint32_t row, uint32_t csv_idx)
+        : ID{ ID }
+        , row{ row }
+        , csv_idx{ csv_idx }
+    {}
+};
+
 std::vector<ParameterErrorData> checkParameterTableCSVErrors(const std::string& params_root);
 std::vector<ParameterErrorData> checkParameterTableCSVErrors(const std::filesystem::path& params_root);
 
-uint32_t nextAvailableID(const std::filesystem::path& root_path);
+std::vector<EntityErrorData> checkEntityTableCSVErrors(const std::string& entities_root);
+std::vector<EntityErrorData> checkEntityTableCSVErrors(const std::filesystem::path& entities_root);
+
+uint32_t nextAvailableParamID(const std::filesystem::path& root_path);
+uint32_t nextAvailableEntityID(const std::filesystem::path& root_path);

--- a/src/CLI/GinnungagapCLI/CSVUnpack/MXEUtil.cpp
+++ b/src/CLI/GinnungagapCLI/CSVUnpack/MXEUtil.cpp
@@ -1,0 +1,130 @@
+#include "MXEInfo.hpp"
+#include "CSVFile.hpp"
+#include "MXEUtil.hpp"
+
+void addEntityToCSVUnpack(const std::filesystem::path& root_path, const std::string& entity_name, const FlatEntityDefMap& entity_defmap)
+{
+	const std::filesystem::path params_root = root_path / "parameters";
+	const std::filesystem::path metadata_path = root_path / "metadata.txt";
+	const std::filesystem::path entities_root = root_path / "entities";
+	const std::filesystem::path entity_csv = entities_root / (entity_name + ".csv");
+
+	if (!doesFileExist(metadata_path))
+	{
+		std::cout << "Error: Not an MXE unpack. File " << metadata_path.string() << " does not exist." << std::endl;
+		exit(1);
+	}
+	// Entities may not exist, e.g. game_info.mxe
+	if (!doesDirectoryExist(entities_root))
+	{
+		std::cout << "'entities' directory does not exist in MXE unpack" 
+			      << "Add it if you know what you're doing"
+				  << std::endl;
+		return;
+	}
+	// Params may not exist... in theory
+	if (!doesDirectoryExist(entities_root))
+	{
+		std::cout << "''parameters' directory does not exist in MXE unpack."
+			      << "Add it if you know what you're doing."
+			      << std::endl;
+		return;
+	}
+	// Given entity CSV may not exist
+	if (!doesFileExist(entity_csv))
+	{
+		std::cout << "Entity CSV '"<< entity_csv <<"' does not exist in MXE unpack."
+			      << "Add it if you know what you're doing."
+			      << std::endl;
+		return;
+	}
+	// Make a list of param CSVs and check they exist
+	std::vector<std::pair<std::filesystem::path, uint32_t>> params;
+	params.reserve(5);
+
+	if (!entity_defmap.contains(entity_name))
+	{
+		std::cout << "Unknown entity type: " << entity_name << std::endl;
+		return;
+	}
+	const auto& edef = entity_defmap.at(entity_name);
+	uint32_t next_param_id = nextAvailableParamID(root_path);
+	for (const auto& comp : edef.components)
+		for (const auto& p : comp.parameters) {
+			//build csv and ID list to use
+			params.push_back(std::pair(params_root / (p.param_type + ".csv"), next_param_id));
+			if (!doesFileExist(params.back().first))
+			{
+				std::cout << "Param CSV '" << params.back().first << "' does not exist in MXE unpack."
+					<< "Add it if you know what you're doing."
+					<< std::endl;
+				return;
+			}
+			next_param_id++;
+		}
+	// Get new entity ID and write it out
+	uint32_t entityID = nextAvailableEntityID(root_path);
+	std::ofstream ent_file(entity_csv.string(), std::ios::app);
+	try 
+	{
+		std::cout << "Writing new entity dummy to CSV: " << entity_csv;
+		// Assume it is a proper csv and pray
+		ent_file << entityID << "," << "new_" << entityID << ",0,";
+		// We already iterated over parameters and generated IDs
+		for (int i = 0; i < params.size(); ++i) {
+			ent_file << params.at(i).second;
+			if (i < params.size() - 1)
+				ent_file << ",";
+		}
+		ent_file << "\n";
+		ent_file.close();
+		std::cout << " - Complete." << std::endl;
+	}
+	catch (std::exception e) {
+		std::cout << std::endl << "Error writing CSV: " << entity_csv << std::endl;
+		ent_file.close();
+		return;
+	}
+	// Now add params
+	for(const auto& v : params)
+	{
+		addParamToCSVUnpack(v.first, v.second);
+	}
+}
+
+void addParamToCSVUnpack(const std::filesystem::path& param_csv, uint32_t param_id)
+{
+	// read CSV header and count commas :)
+	std::ifstream param_file(param_csv, std::ios::in);
+	std::string header;
+	std::getline(param_file, header);
+	int count = 0;
+	for (int i = 0; i < header.size(); ++i)
+		if (header.at(i) == ',')
+			count++;
+	param_file.close();
+	
+	//now print ID, Name, fill the rest with -1
+	std::ofstream param_file_out(param_csv, std::ios::app);
+	try
+	{
+		std::cout << "Writing new param dummy to CSV: " << param_csv;
+		param_file_out << param_id << ",";
+		param_file_out << "new_" << param_id << ",";
+		param_file_out << "dummy Type string,";
+		for (int i = 2; i < count; ++i)
+		{
+			param_file_out << "-1";
+			if (i < count - 1)
+				param_file_out << ",";
+		}
+		param_file_out << "\n";
+		param_file_out.close();
+		std::cout << " - Complete." << std::endl;
+	}
+	catch (std::exception e) {
+		std::cout << std::endl << "Error writing CSV: " << param_csv << std::endl;
+		param_file_out.close();
+		return;
+	}
+}

--- a/src/CLI/GinnungagapCLI/CSVUnpack/MXEUtil.hpp
+++ b/src/CLI/GinnungagapCLI/CSVUnpack/MXEUtil.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#include "GinnungagapCore/structs/Valkyria/Containers/Database/MXEN/MXEC/ParametersTable/ParamDefinitions/Load.hpp"
+
+void addEntityToCSVUnpack(const std::filesystem::path& root_path, const std::string& entity_name, const FlatEntityDefMap& entity_defmap);
+
+void addParamToCSVUnpack(const std::filesystem::path& param_csv, uint32_t param_id);


### PR DESCRIPTION
Basic implementation of ability to insert a new blank entity and corresponding blank parameters with `--add-entity path/to/unpack/root/ <EntityName>`

Currently will bail if any relevant CSVs (entity or its required params) are not present and ask user to add them.
Uses reading CSV header to calculate the correct amount of dummy fields to fill.
Everything in params is filled with -1's regardless of type.
The order of param IDs filled into the Entity CSV is opposite from the one naturally used by MXE.

Unrelated fix - die with a useful message, rather than silently, if loading assets/ JSONs throws an exception.